### PR TITLE
Update patcher.js

### DIFF
--- a/patcher/patcher.js
+++ b/patcher/patcher.js
@@ -7,10 +7,10 @@ var KeyTree = require("can-key-tree");
 var canSymbol = require("can-symbol");
 var diff = require('../list/list');
 var queues = require("can-queues");
-var canSymbol = require("can-symbol");
 
-var onValueSymbol = canSymbol.for("can.onValue"),
-	offValueSymbol = canSymbol.for("can.offValue");
+
+var onValueSymbol = canSymbol.for("can.onValue");
+var offValueSymbol = canSymbol.for("can.offValue");
 var onPatchesSymbol = canSymbol.for("can.onPatches");
 var offPatchesSymbol = canSymbol.for("can.offPatches");
 


### PR DESCRIPTION
throw an error in rollup `var canSymbol = require("can-symbol");` was declared twice